### PR TITLE
Fix compilation issues on zig  0.12.0-dev.2150+63de8a598

### DIFF
--- a/Package.zig
+++ b/Package.zig
@@ -111,7 +111,9 @@ pub fn fetchAndUnpack(
             const path = try global_cache_directory.join(gpa, &.{tmp_dir_sub_path});
             errdefer gpa.free(path);
 
-            const iterable_dir = try global_cache_directory.handle.makeOpenPath(tmp_dir_sub_path, .{});
+            const iterable_dir = try global_cache_directory.handle.makeOpenPath(tmp_dir_sub_path, .{
+                .iterate = true,
+            });
             errdefer iterable_dir.close();
 
             break :d .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,14 @@
 .{
     .name = "aws-zig",
     .version = "0.0.1",
+    .paths = .{""},
 
     .dependencies = .{
         .smithy = .{
-            .url = "https://git.lerch.org/lobo/smithy/archive/41b61745d25a65817209dd5dddbb5f9b66896a99.tar.gz",
-            .hash = "122087deb0ae309b2258d59b40d82fe5921fdfc35b420bb59033244851f7f276fa34",
+            .url = "https://github.com/melhindi/smithy/archive/refs/heads/master.tar.gz",
+            .hash = "12209568cc5c0bad2fcf6a62dbf6792fbbf3727214da98b21c390fc399f6dd743d3a",
+            // .url = "https://git.lerch.org/lobo/smithy/archive/41b61745d25a65817209dd5dddbb5f9b66896a99.tar.gz",
+            // .hash = "122087deb0ae309b2258d59b40d82fe5921fdfc35b420bb59033244851f7f276fa34",
         },
     },
 }

--- a/codegen/src/Hasher.zig
+++ b/codegen/src/Hasher.zig
@@ -77,13 +77,13 @@ pub fn hex64(x: u64) [16]u8 {
     return result;
 }
 
-pub const walkerFn = *const fn (std.fs.IterableDir.Walker.WalkerEntry) bool;
+pub const walkerFn = *const fn (std.fs.Dir.Walker.WalkerEntry) bool;
 
-fn included(entry: std.fs.IterableDir.Walker.WalkerEntry) bool {
+fn included(entry: std.fs.Dir.Walker.WalkerEntry) bool {
     _ = entry;
     return true;
 }
-fn excluded(entry: std.fs.IterableDir.Walker.WalkerEntry) bool {
+fn excluded(entry: std.fs.Dir.Walker.WalkerEntry) bool {
     _ = entry;
     return false;
 }
@@ -96,7 +96,7 @@ pub const ComputeDirectoryOptions = struct {
 
 pub fn computeDirectoryHash(
     thread_pool: *std.Thread.Pool,
-    dir: std.fs.IterableDir,
+    dir: std.fs.Dir,
     options: *ComputeDirectoryOptions,
 ) ![Hash.digest_length]u8 {
     const gpa = thread_pool.allocator;
@@ -138,7 +138,7 @@ pub fn computeDirectoryHash(
                 .failure = undefined, // to be populated by the worker
             };
             wait_group.start();
-            try thread_pool.spawn(workerHashFile, .{ dir.dir, hashed_file, &wait_group });
+            try thread_pool.spawn(workerHashFile, .{ dir, hashed_file, &wait_group });
 
             try all_files.append(hashed_file);
         }

--- a/codegen/src/main.zig
+++ b/codegen/src/main.zig
@@ -17,7 +17,7 @@ pub fn main() anyerror!void {
 
     var output_dir = std.fs.cwd();
     defer if (output_dir.fd > 0) output_dir.close();
-    var models_dir: ?std.fs.IterableDir = null;
+    var models_dir: ?std.fs.Dir = null;
     defer if (models_dir) |*m| m.close();
     for (args, 0..) |arg, i| {
         if (std.mem.eql(u8, "--help", arg) or
@@ -31,13 +31,13 @@ pub fn main() anyerror!void {
         if (std.mem.eql(u8, "--output", arg))
             output_dir = try output_dir.makeOpenPath(args[i + 1], .{});
         if (std.mem.eql(u8, "--models", arg))
-            models_dir = try std.fs.cwd().openIterableDir(args[i + 1], .{});
+            models_dir = try std.fs.cwd().openDir(args[i + 1], .{ .iterate = true });
     }
     // TODO: Seems like we should remove this in favor of a package
     try output_dir.writeFile("json.zig", json_zig);
 
     // TODO: We need a different way to handle this file...
-    var manifest_file_started = false;
+    const manifest_file_started = false;
     var manifest_file: std.fs.File = undefined;
     defer if (manifest_file_started) manifest_file.close();
     var manifest: std.fs.File.Writer = undefined;
@@ -71,11 +71,11 @@ pub fn main() anyerror!void {
         // this is our normal mode of operation and where initial optimizations
         // can be made
         if (models_dir) |m| {
-            var cwd = try std.fs.cwd().openDir(".", .{});
+            var cwd = try std.fs.cwd().openDir(".", .{ .iterate = true });
             defer cwd.close();
             defer cwd.setAsCwd() catch unreachable;
 
-            try m.dir.setAsCwd();
+            try m.setAsCwd();
             try processDirectories(m, output_dir);
         }
     }
@@ -87,7 +87,7 @@ const OutputManifest = struct {
     model_dir_hash_digest: [Hasher.hex_multihash_len]u8,
     output_dir_hash_digest: [Hasher.hex_multihash_len]u8,
 };
-fn processDirectories(models_dir: std.fs.IterableDir, output_dir: std.fs.Dir) !void {
+fn processDirectories(models_dir: std.fs.Dir, output_dir: std.fs.Dir) !void {
     // Let's get ready to hash!!
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -131,15 +131,15 @@ fn processDirectories(models_dir: std.fs.IterableDir, output_dir: std.fs.Dir) !v
 }
 
 var model_digest: ?[Hasher.hex_multihash_len]u8 = null;
-fn calculateDigests(models_dir: std.fs.IterableDir, output_dir: std.fs.Dir, thread_pool: *std.Thread.Pool) !OutputManifest {
+fn calculateDigests(models_dir: std.fs.Dir, output_dir: std.fs.Dir, thread_pool: *std.Thread.Pool) !OutputManifest {
     const model_hash = if (model_digest) |m| m[0..Hasher.digest_len].* else try Hasher.computeDirectoryHash(thread_pool, models_dir, @constCast(&Hasher.ComputeDirectoryOptions{
         .isIncluded = struct {
-            pub fn include(entry: std.fs.IterableDir.Walker.WalkerEntry) bool {
+            pub fn include(entry: std.fs.Dir.Walker.WalkerEntry) bool {
                 return std.mem.endsWith(u8, entry.basename, ".json");
             }
         }.include,
         .isExcluded = struct {
-            pub fn exclude(entry: std.fs.IterableDir.Walker.WalkerEntry) bool {
+            pub fn exclude(entry: std.fs.Dir.Walker.WalkerEntry) bool {
                 _ = entry;
                 return false;
             }
@@ -148,14 +148,14 @@ fn calculateDigests(models_dir: std.fs.IterableDir, output_dir: std.fs.Dir, thre
     }));
     if (verbose) std.log.info("Model directory hash: {s}", .{model_digest orelse Hasher.hexDigest(model_hash)});
 
-    const output_hash = try Hasher.computeDirectoryHash(thread_pool, try output_dir.openIterableDir(".", .{}), @constCast(&Hasher.ComputeDirectoryOptions{
+    const output_hash = try Hasher.computeDirectoryHash(thread_pool, try output_dir.openDir(".", .{ .iterate = true }), @constCast(&Hasher.ComputeDirectoryOptions{
         .isIncluded = struct {
-            pub fn include(entry: std.fs.IterableDir.Walker.WalkerEntry) bool {
+            pub fn include(entry: std.fs.Dir.Walker.WalkerEntry) bool {
                 return std.mem.endsWith(u8, entry.basename, ".zig");
             }
         }.include,
         .isExcluded = struct {
-            pub fn exclude(entry: std.fs.IterableDir.Walker.WalkerEntry) bool {
+            pub fn exclude(entry: std.fs.Dir.Walker.WalkerEntry) bool {
                 _ = entry;
                 return false;
             }
@@ -201,7 +201,7 @@ fn processFile(file_name: []const u8, output_dir: std.fs.Dir, manifest: anytype)
     defer allocator.free(output_file_name);
     for (service_names) |name| {
         const seperator = if (output_file_name.len > 0) "-" else "";
-        var new_output_file_name = try std.fmt.allocPrint(
+        const new_output_file_name = try std.fmt.allocPrint(
             allocator,
             "{s}{s}{s}",
             .{ output_file_name, seperator, name },
@@ -211,7 +211,7 @@ fn processFile(file_name: []const u8, output_dir: std.fs.Dir, manifest: anytype)
     }
     {
         // append .zig on to the file name
-        var new_output_file_name = try std.fmt.allocPrint(
+        const new_output_file_name = try std.fmt.allocPrint(
             allocator,
             "{s}.zig",
             .{output_file_name},
@@ -337,7 +337,7 @@ fn generateServices(allocator: std.mem.Allocator, comptime _: []const u8, file: 
     var generated = std.StringHashMap(void).init(allocator);
     defer generated.deinit();
 
-    var state = FileGenerationState{
+    const state = FileGenerationState{
         .shape_references = shape_references,
         .additional_types_to_generate = &unresolved,
         .additional_types_generated = &generated,
@@ -345,8 +345,8 @@ fn generateServices(allocator: std.mem.Allocator, comptime _: []const u8, file: 
     };
     for (services.items) |service| {
         var sdk_id: []const u8 = undefined;
-        var version: []const u8 = service.shape.service.version;
-        var name: []const u8 = service.name;
+        const version: []const u8 = service.shape.service.version;
+        const name: []const u8 = service.name;
         var arn_namespace: []const u8 = undefined;
         var sigv4_name: []const u8 = undefined;
         var endpoint_prefix: []const u8 = undefined;

--- a/codegen/src/main.zig
+++ b/codegen/src/main.zig
@@ -29,9 +29,13 @@ pub fn main() anyerror!void {
             std.process.exit(0);
         }
         if (std.mem.eql(u8, "--output", arg))
-            output_dir = try output_dir.makeOpenPath(args[i + 1], .{});
+            output_dir = try output_dir.makeOpenPath(args[i + 1], .{
+                .iterate = true,
+            });
         if (std.mem.eql(u8, "--models", arg))
-            models_dir = try std.fs.cwd().openDir(args[i + 1], .{ .iterate = true });
+            models_dir = try std.fs.cwd().openDir(args[i + 1], .{
+                .iterate = true,
+            });
     }
     // TODO: Seems like we should remove this in favor of a package
     try output_dir.writeFile("json.zig", json_zig);

--- a/example/build.zig
+++ b/example/build.zig
@@ -35,7 +35,7 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    exe.addModule("aws", aws_dep.module("aws"));
+    exe.root_module.addImport("aws", aws_dep.module("aws"));
     // This declares intent for the executable to be installed into the
     // standard location when the user invokes the "install" step (the default
     // step when running `zig build`).

--- a/example/build.zig.zon
+++ b/example/build.zig.zon
@@ -1,15 +1,20 @@
 .{
     .name = "myapp",
     .version = "0.0.1",
+    .paths = .{""},
 
     .dependencies = .{
         .aws = .{
-            .url = "https://git.lerch.org/api/packages/lobo/generic/aws-sdk-with-models/d08d0f338fb86f7d679a998ff4f65f4e2d0db595/d08d0f338fb86f7d679a998ff4f65f4e2d0db595-with-models.tar.gz",
-            .hash = "1220c8871d93592680ea2dcc88cc52fb4f0effabeed0584d2a5c54f93825741b7c66",
+            .url = "https://github.com/melhindi/aws-sdk-for-zig/archive/refs/heads/master.tar.gz",
+            .hash = "12205d584b2ef32dd5346a25f02ad3958eb221a08a47ad8d81605d3e3512364da5f0",
+            // .url = "https://git.lerch.org/api/packages/lobo/generic/aws-sdk-with-models/d08d0f338fb86f7d679a998ff4f65f4e2d0db595/d08d0f338fb86f7d679a998ff4f65f4e2d0db595-with-models.tar.gz",
+            // .hash = "1220c8871d93592680ea2dcc88cc52fb4f0effabeed0584d2a5c54f93825741b7c66",
         },
         .smithy = .{
-            .url = "https://git.lerch.org/lobo/smithy/archive/41b61745d25a65817209dd5dddbb5f9b66896a99.tar.gz",
-            .hash = "122087deb0ae309b2258d59b40d82fe5921fdfc35b420bb59033244851f7f276fa34",
+            .url = "https://github.com/melhindi/smithy/archive/refs/heads/master.tar.gz",
+            .hash = "12209568cc5c0bad2fcf6a62dbf6792fbbf3727214da98b21c390fc399f6dd743d3a",
+            // .url = "https://git.lerch.org/lobo/smithy/archive/41b61745d25a65817209dd5dddbb5f9b66896a99.tar.gz",
+            // .hash = "122087deb0ae309b2258d59b40d82fe5921fdfc35b420bb59033244851f7f276fa34",
         },
     },
 }

--- a/src/aws.zig
+++ b/src/aws.zig
@@ -31,7 +31,7 @@ pub const services = servicemodel.services;
 pub const Services = servicemodel.Services;
 
 pub const ClientOptions = struct {
-    proxy: ?std.http.Client.HttpProxy = null,
+    proxy: ?std.http.Client.Proxy = null,
 };
 pub const Client = struct {
     allocator: std.mem.Allocator,
@@ -365,7 +365,7 @@ pub fn Request(comptime request_action: anytype) type {
                     .raw_parsed = .{ .raw = .{} },
                     .allocator = options.client.allocator,
                 };
-                var body_field = @field(rc.response, action.Response.http_payload);
+                const body_field = @field(rc.response, action.Response.http_payload);
                 const BodyField = @TypeOf(body_field);
                 if (BodyField == []const u8 or BodyField == ?[]const u8) {
                     expected_body_field_len = 0;
@@ -875,7 +875,7 @@ fn FullResponse(comptime action: anytype) type {
                 }
             }
             if (@hasDecl(Response, "http_payload")) {
-                var body_field = @field(self.response, Response.http_payload);
+                const body_field = @field(self.response, Response.http_payload);
                 const BodyField = @TypeOf(body_field);
                 if (BodyField == []const u8) {
                     self.allocator.free(body_field);
@@ -1465,7 +1465,7 @@ fn processRequest(options: *TestOptions, server: *std.http.Server) !void {
     else
         res.transfer_encoding = .chunked;
 
-    try res.do();
+    try res.send();
     _ = try res.writer().writeAll(response_bytes);
     try res.finish();
     log.debug(

--- a/src/aws_signing.zig
+++ b/src/aws_signing.zig
@@ -177,7 +177,7 @@ pub fn signRequest(allocator: std.mem.Allocator, request: base.Request, config: 
         };
     }
     errdefer freeSignedRequest(allocator, &rc, config);
-    std.mem.copy(base.Header, newheaders, oldheaders);
+    @memcpy(newheaders[0..oldheaders.len], oldheaders);
     newheaders[newheaders.len - 3] = base.Header{
         .name = "X-Amz-Date",
         .value = signing_iso8601,
@@ -364,7 +364,7 @@ fn verifyParsedAuthorization(
     const service = credential_iterator.next().?;
     const aws4_request = credential_iterator.next().?;
     if (!std.mem.eql(u8, aws4_request, "aws4_request")) return error.UnexpectedCredentialValue;
-    var config = Config{
+    const config = Config{
         .service = service,
         .credentials = credentials,
         .region = region,
@@ -444,7 +444,7 @@ fn getSigningKey(allocator: std.mem.Allocator, signing_date: []const u8, config:
         \\  region: {s}
         \\  service: {s}
     , .{ signing_date, config.region, config.service });
-    var secret = try std.fmt.allocPrint(allocator, "AWS4{s}", .{config.credentials.secret_key});
+    const secret = try std.fmt.allocPrint(allocator, "AWS4{s}", .{config.credentials.secret_key});
     defer {
         // secureZero avoids compiler optimizations that may say
         // "WTF are you doing this thing? Looks like nothing to me. It's silly and we will remove it"
@@ -716,7 +716,7 @@ fn canonicalQueryString(allocator: std.mem.Allocator, path: []const u8) ![]const
     for (sort_me.items) |i| {
         if (!first) try normalized.append('&');
         first = false;
-        var first_equals = std.mem.indexOf(u8, i, "=");
+        const first_equals = std.mem.indexOf(u8, i, "=");
         if (first_equals == null) {
             // Rare. This is "foo="
             const normed_item = try encodeUri(allocator, i);
@@ -744,7 +744,7 @@ fn canonicalQueryString(allocator: std.mem.Allocator, path: []const u8) ![]const
 }
 
 fn replace(allocator: std.mem.Allocator, haystack: []const u8, needle: []const u8, replacement_value: []const u8) ![]const u8 {
-    var buffer = try allocator.alloc(u8, std.mem.replacementSize(u8, haystack, needle, replacement_value));
+    const buffer = try allocator.alloc(u8, std.mem.replacementSize(u8, haystack, needle, replacement_value));
     _ = std.mem.replace(u8, haystack, needle, replacement_value, buffer);
     return buffer;
 }
@@ -837,7 +837,7 @@ fn canonicalHeaders(allocator: std.mem.Allocator, headers: []base.Header, servic
 
 fn canonicalHeaderValue(allocator: std.mem.Allocator, value: []const u8) ![]const u8 {
     var started = false;
-    var in_quote = false;
+    const in_quote = false;
     var start: usize = 0;
     const rc = try allocator.alloc(u8, value.len);
     var rc_inx: usize = 0;
@@ -1002,7 +1002,7 @@ test "can sign" {
     try headers.append(.{ .name = "Content-Type", .value = "application/x-www-form-urlencoded; charset=utf-8" });
     try headers.append(.{ .name = "Content-Length", .value = "13" });
     try headers.append(.{ .name = "Host", .value = "example.amazonaws.com" });
-    var req = base.Request{
+    const req = base.Request{
         .path = "/",
         .query = "",
         .body = "Param1=value1",
@@ -1071,7 +1071,7 @@ test "can verify server request" {
 
     var buf = "bar".*;
     var fis = std.io.fixedBufferStream(&buf);
-    var request = std.http.Server.Request{
+    const request = std.http.Server.Request{
         .method = std.http.Method.PUT,
         .target = "/mysfitszj3t6webstack-hostingbucketa91a61fe-1ep3ezkgwpxr0/i/am/a/teapot/foo?x-id=PutObject",
         .version = .@"HTTP/1.1",

--- a/src/date.zig
+++ b/src/date.zig
@@ -21,7 +21,7 @@ pub fn timestampToDateTime(timestamp: i64) DateTime {
     const DAY_NUMBER_ADJUSTED_1970_01_01 = 719468; //* Day number relates to March 1st */
 
     var dayN: u64 = DAY_NUMBER_ADJUSTED_1970_01_01 + unixtime / SECONDS_PER_DAY;
-    var seconds_since_midnight: u64 = unixtime % SECONDS_PER_DAY;
+    const seconds_since_midnight: u64 = unixtime % SECONDS_PER_DAY;
     var temp: u64 = 0;
 
     // Leap year rules for Gregorian Calendars
@@ -37,7 +37,7 @@ pub fn timestampToDateTime(timestamp: i64) DateTime {
 
     // dayN calculates the days of the year in relation to March 1
     var month = @as(u8, @intCast((5 * dayN + 2) / 153));
-    var day = @as(u8, @intCast(dayN - (@as(u64, @intCast(month)) * 153 + 2) / 5 + 1));
+    const day = @as(u8, @intCast(dayN - (@as(u64, @intCast(month)) * 153 + 2) / 5 + 1));
     //  153 = 31+30+31+30+31 Days for the 5 months from March through July
     //  153 = 31+30+31+30+31 Days for the 5 months from August through December
     //        31+28          Days for January and February (see below)
@@ -50,9 +50,9 @@ pub fn timestampToDateTime(timestamp: i64) DateTime {
         year += 1;
     }
 
-    var hours = @as(u8, @intCast(seconds_since_midnight / 3600));
-    var minutes = @as(u8, @intCast(seconds_since_midnight % 3600 / 60));
-    var seconds = @as(u8, @intCast(seconds_since_midnight % 60));
+    const hours = @as(u8, @intCast(seconds_since_midnight / 3600));
+    const minutes = @as(u8, @intCast(seconds_since_midnight % 3600 / 60));
+    const seconds = @as(u8, @intCast(seconds_since_midnight % 60));
 
     return DateTime{ .day = day, .month = month, .year = year, .hour = hours, .minute = minutes, .second = seconds };
 }
@@ -275,10 +275,10 @@ fn secondsBetween(start: DateTime, end: DateTime) DateTimeToTimestampError!i64 {
         return (try secondsBetween(new_start, end)) - seconds_into_start_year;
     }
     const leap_years_between = leapYearsBetween(start.year, end.year);
-    var add_days: u1 = 0;
+    const add_days: u1 = 0;
     const years_diff = end.year - start.year;
     // log.debug("Years from epoch: {d}, Leap years: {d}", .{ years_diff, leap_years_between });
-    var days_diff: i32 = (years_diff * DAYS_PER_YEAR) + leap_years_between + add_days;
+    const days_diff: i32 = (years_diff * DAYS_PER_YEAR) + leap_years_between + add_days;
     // log.debug("Days with leap year, without month: {d}", .{days_diff});
 
     const seconds_into_year = secondsFromBeginningOfYear(
@@ -306,7 +306,7 @@ fn secondsFromBeginningOfYear(year: u16, month: u8, day: u8, hour: u8, minute: u
     const normal_days_per_month: [12]u5 = .{ 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
     const days_per_month = if (current_year_is_leap_year) leap_year_days_per_month else normal_days_per_month;
     var current_month: usize = 1;
-    var end_month = month;
+    const end_month = month;
     var days_diff: u32 = 0;
     while (current_month != end_month) {
         days_diff += days_per_month[current_month - 1]; // months are 1-based vs array is 0-based

--- a/src/http_client_17015_issue.zig
+++ b/src/http_client_17015_issue.zig
@@ -10,8 +10,8 @@ const Uri = std.Uri;
 /// only the two w.print lines for req.uri 16 and 18 lines down from this comment
 ///////////////////////////////////////////////////////////////////////////
 /// Send the request to the server.
-pub fn start(req: *std.http.Client.Request) std.http.Client.Request.StartError!void {
-    var buffered = std.io.bufferedWriter(req.connection.?.data.writer());
+pub fn send(req: *std.http.Client.Request) std.http.Client.Request.SendError!void {
+    var buffered = std.io.bufferedWriter(req.connection.?.writer());
     const w = buffered.writer();
 
     try w.writeAll(@tagName(req.method));
@@ -21,7 +21,7 @@ pub fn start(req: *std.http.Client.Request) std.http.Client.Request.StartError!v
         try w.writeAll(req.uri.host.?);
         try w.writeByte(':');
         try w.print("{}", .{req.uri.port.?});
-    } else if (req.connection.?.data.proxied) {
+    } else if (req.connection.?.proxied) {
         // proxied connections require the full uri
         try format(req.uri, "+/", .{}, w);
     } else {

--- a/src/json.zig
+++ b/src/json.zig
@@ -1762,7 +1762,7 @@ fn parseInternal(comptime T: type, token: Token, tokens: *TokenStream, options: 
                     var r: T = undefined;
                     const source_slice = stringToken.slice(tokens.slice, tokens.i - 1);
                     switch (stringToken.escapes) {
-                        .None => mem.copy(u8, &r, source_slice),
+                        .None => @memcpy(&r, source_slice),
                         .Some => try unescapeValidString(&r, source_slice),
                     }
                     return r;
@@ -2019,7 +2019,7 @@ test "parse into tagged union" {
     }
 
     { // failing allocations should be bubbled up instantly without trying next member
-        var fail_alloc = testing.FailingAllocator.init(testing.allocator, 0);
+        var fail_alloc = testing.FailingAllocator.init(testing.allocator, .{});
         const options = ParseOptions{ .allocator = fail_alloc.allocator() };
         const T = union(enum) {
             // both fields here match the input
@@ -2067,7 +2067,7 @@ test "parse union bubbles up AllocatorRequired" {
 }
 
 test "parseFree descends into tagged union" {
-    var fail_alloc = testing.FailingAllocator.init(testing.allocator, 1);
+    var fail_alloc = testing.FailingAllocator.init(testing.allocator, .{});
     const options = ParseOptions{ .allocator = fail_alloc.allocator() };
     const T = union(enum) {
         int: i32,
@@ -2299,7 +2299,7 @@ pub const Parser = struct {
             },
             .ObjectValue => {
                 var object = &p.stack.items[p.stack.items.len - 2].Object;
-                var key = p.stack.items[p.stack.items.len - 1].String;
+                const key = p.stack.items[p.stack.items.len - 1].String;
 
                 switch (token) {
                     .ObjectBegin => {
@@ -2827,14 +2827,14 @@ pub fn stringify(
             }
         },
         .Enum => {
-            if (comptime std.meta.trait.hasFn("jsonStringify")(T)) {
+            if (comptime std.meta.hasFn(T, "jsonStringify")) {
                 return value.jsonStringify(options, out_stream);
             }
 
             @compileError("Unable to stringify enum '" ++ @typeName(T) ++ "'");
         },
         .Union => {
-            if (comptime std.meta.trait.hasFn("jsonStringify")(T)) {
+            if (comptime std.meta.hasFn(T, "jsonStringify")) {
                 return value.jsonStringify(options, out_stream);
             }
 
@@ -2850,7 +2850,7 @@ pub fn stringify(
             }
         },
         .Struct => |S| {
-            if (comptime std.meta.trait.hasFn("jsonStringify")(T)) {
+            if (comptime std.meta.hasFn(T, "jsonStringify")) {
                 return value.jsonStringify(options, out_stream);
             }
 
@@ -2874,11 +2874,11 @@ pub fn stringify(
                     try child_whitespace.outputIndent(out_stream);
                 }
                 var field_written = false;
-                if (comptime std.meta.trait.hasFn("jsonStringifyField")(T))
+                if (comptime std.meta.hasFn(T, "jsonStringifyField"))
                     field_written = try value.jsonStringifyField(Field.name, child_options, out_stream);
 
                 if (!field_written) {
-                    if (comptime std.meta.trait.hasFn("fieldNameFor")(T)) {
+                    if (comptime std.meta.hasFn(T, "fieldNameFor")) {
                         const name = value.fieldNameFor(Field.name);
                         try stringify(name, options, out_stream);
                     } else {

--- a/src/main.zig
+++ b/src/main.zig
@@ -71,7 +71,7 @@ pub fn main() anyerror!void {
     defer bw.flush() catch unreachable;
     const stdout = bw.writer();
     var arg0: ?[]const u8 = null;
-    var proxy: ?std.http.Client.HttpProxy = null;
+    var proxy: ?std.http.Client.Proxy = null;
     while (args.next()) |arg| {
         if (arg0 == null) arg0 = arg;
         if (std.mem.eql(u8, "-h", arg) or std.mem.eql(u8, "--help", arg)) {
@@ -87,7 +87,7 @@ pub fn main() anyerror!void {
             return;
         }
         if (std.mem.eql(u8, "-x", arg) or std.mem.eql(u8, "--proxy", arg)) {
-            proxy = try proxyFromString(args.next().?); // parse stuff
+            proxy = try proxyFromString(allocator, args.next().?); // parse stuff
             continue;
         }
         if (std.mem.startsWith(u8, arg, "-v")) {
@@ -353,10 +353,13 @@ pub fn main() anyerror!void {
     std.log.info("===== Tests complete =====", .{});
 }
 
-fn proxyFromString(string: []const u8) !std.http.Client.HttpProxy {
-    var rc = std.http.Client.HttpProxy{
+fn proxyFromString(allocator: std.mem.Allocator, string: []const u8) !std.http.Client.Proxy {
+    var rc = std.http.Client.Proxy{
+        .headers = std.http.Headers{ .allocator = allocator },
+        .allocator = allocator,
         .protocol = undefined,
         .host = undefined,
+        .port = undefined,
     };
     var remaining: []const u8 = string;
     if (std.mem.startsWith(u8, string, "http://")) {

--- a/src/xml.zig
+++ b/src/xml.zig
@@ -260,7 +260,7 @@ const ParseContext = struct {
             begin = prev_nl + 1;
         }
 
-        var end = mem.indexOfScalarPos(u8, self.source, self.offset, '\n') orelse self.source.len;
+        const end = mem.indexOfScalarPos(u8, self.source, self.offset, '\n') orelse self.source.len;
         return self.source[begin..end];
     }
 };

--- a/src/xml_shaper.zig
+++ b/src/xml_shaper.zig
@@ -214,9 +214,9 @@ fn parseInternal(comptime T: type, element: *xml.Element, options: ParseOptions)
 
             log.debug("Processing fields in struct: {s}", .{@typeName(T)});
             inline for (struct_info.fields, 0..) |field, i| {
-                var name = field.name;
+                var name: []const u8 = field.name;
                 var found_value = false;
-                if (comptime std.meta.trait.hasFn("fieldNameFor")(T))
+                if (comptime std.meta.hasFn(T, "fieldNameFor"))
                     name = r.fieldNameFor(field.name);
                 log.debug("Field name: {s}, Element: {s}, Adjusted field name: {s}", .{ field.name, element.tag, name });
                 var iterator = element.findChildrenByTag(name);


### PR DESCRIPTION
Hi @elerch,
I want to use the aws-sdk-for-zig for a project that I am developing on zig master.
These where the changes required to compile on 0.12.0-dev.2150+63de8a598.
While the code compiles, for some reason I have not investigated yet, the tests get stuck at step `[6/21] zig test Debug riscv64-linux... LLVM Emit Object...`

As I cannot open a PR on your self-hosted Gitea instance, I am opening this PR on the github mirror repository.
Happy to contribute also in future if you accept PRs.