### PR TITLE
Make aws module depend on codegen

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -95,7 +95,7 @@ pub fn build(b: *Builder) !void {
         .target = b.graph.host,
         .optimize = if (b.verbose) .Debug else .ReleaseSafe,
     });
-    cg_exe.root_module.addImport("smithy", smithy_dep.module("smithy"));
+    cg_exe.root_module.addImport("smithy", smithy_module);
     var cg_cmd = b.addRunArtifact(cg_exe);
     cg_cmd.addArg("--models");
     const hash = hash_blk: {
@@ -146,6 +146,9 @@ pub fn build(b: *Builder) !void {
         .target = target,
         .optimize = optimize,
     });
+    service_manifest_module.addImport("smithy", smithy_module);
+
+    exe.root_module.addImport("service_manifest", service_manifest_module);
 
     // Expose module to others
     _ = b.addModule("aws", .{
@@ -190,7 +193,8 @@ pub fn build(b: *Builder) !void {
             .target = b.resolveTargetQuery(t),
             .optimize = optimize,
         });
-        unit_tests.root_module.addImport("smithy", smithy_dep.module("smithy"));
+        unit_tests.root_module.addImport("smithy", smithy_module);
+        unit_tests.root_module.addImport("service_manifest", service_manifest_module);
         unit_tests.step.dependOn(cg);
 
         const run_unit_tests = b.addRunArtifact(unit_tests);
@@ -213,7 +217,8 @@ pub fn build(b: *Builder) !void {
         .target = target,
         .optimize = optimize,
     });
-    smoke_test.root_module.addImport("smithy", smithy_dep.module("smithy"));
+    smoke_test.root_module.addImport("smithy", smithy_module);
+    smoke_test.root_module.addImport("service_manifest", service_manifest_module);
     smoke_test.step.dependOn(cg);
 
     const run_smoke_test = b.addRunArtifact(smoke_test);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,6 +5,7 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "codegen",
         "README.md",
         "LICENSE",
     },

--- a/src/servicemodel.zig
+++ b/src/servicemodel.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const service_list = @import("models/service_manifest.zig");
+const service_list = @import("service_manifest");
 const expectEqualStrings = std.testing.expectEqualStrings;
 
 pub fn Services(comptime service_imports: anytype) type {


### PR DESCRIPTION
Before this change, depending on the `aws` module via `build.zig.zon` can not find `service_manifest.zig` because codegen has not run and it does not exist. 

Summary of changes:

- Change `addDirectoryArg` to `addOutputDirectoryArg` so that we can get a generated lazy path to the codegen output folder
- Create a private module `service_manifest` that uses the generated `service_manifest.zig` as the root source file
- Add the `service_manifest` as an import to the `aws` module
- Changed `aws.zig` to import `service_manifest` instead of `models/service_manifest.zig`

Now, when a package depends on the `aws` module, it will run the codegen step first. 