### PR TITLE
Handle empty response bodies and multiple types of timestamps

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -20,5 +20,9 @@
             .url = "https://github.com/aws/aws-sdk-go-v2/archive/58cf6509525a12d64fd826da883bfdbacbd2f00e.tar.gz",
             .hash = "122017a2f3081ce83c23e0c832feb1b8b4176d507b6077f522855dc774bcf83ee315",
         },
+        .zeit = .{
+            .url = "https://github.com/deevus/zeit/archive/refs/heads/rfc1123.tar.gz",
+            .hash = "zeit-0.6.0-5I6bk29nAgDhK6AVMtXMWhkKTYgUncrWjnlI_8X9DPSd",
+        },
     },
 }

--- a/codegen/src/date.zig
+++ b/codegen/src/date.zig
@@ -1,0 +1,53 @@
+const std = @import("std");
+const zeit = @import("zeit");
+
+const DateFormat = enum {
+    rfc1123,
+    iso8601,
+};
+
+pub const Timestamp = enum(zeit.Nanoseconds) {
+    _,
+
+    pub fn jsonStringify(value: Timestamp, options: anytype, out_stream: anytype) !void {
+        _ = options;
+
+        const instant = try zeit.instant(.{
+            .source = .{
+                .unix_nano = @intFromEnum(value),
+            },
+        });
+
+        try out_stream.writeAll("\"");
+        try instant.time().gofmt(out_stream, "Mon, 02 Jan 2006 15:04:05 GMT");
+        try out_stream.writeAll("\"");
+    }
+
+    pub fn parse(val: []const u8) !Timestamp {
+        const date_format = blk: {
+            if (std.ascii.isDigit(val[0])) {
+                break :blk DateFormat.iso8601;
+            } else {
+                break :blk DateFormat.rfc1123;
+            }
+        };
+
+        const ins = try zeit.instant(.{
+            .source = switch (date_format) {
+                DateFormat.iso8601 => .{
+                    .iso8601 = val,
+                },
+                DateFormat.rfc1123 => .{
+                    .rfc1123 = val,
+                },
+            },
+        });
+
+        return @enumFromInt(ins.timestamp);
+    }
+};
+
+test Timestamp {
+    const http_date = try Timestamp.parse("Mon, 02 Jan 2006 15:04:05 GMT");
+    try std.testing.expectEqual(1136214245000, http_date);
+}

--- a/src/date.zig
+++ b/src/date.zig
@@ -3,8 +3,11 @@
 // really requires the TZ DB.
 
 const std = @import("std");
+const codegen_date = @import("date");
 
 const log = std.log.scoped(.date);
+
+pub const Timestamp = codegen_date.Timestamp;
 
 pub const DateTime = struct { day: u8, month: u8, year: u16, hour: u8, minute: u8, second: u8 };
 

--- a/src/xml_shaper.zig
+++ b/src/xml_shaper.zig
@@ -162,8 +162,10 @@ fn parseInternal(comptime T: type, element: *xml.Element, options: ParseOptions)
                 return try parseInternal(optional_info.child, element, options);
             }
         },
-        .@"enum" => |enum_info| {
-            _ = enum_info;
+        .@"enum" => {
+            if (T == date.Timestamp) {
+                return try date.Timestamp.parse(element.children.items[0].CharData);
+            }
             // const numeric: ?enum_info.tag_type = std.fmt.parseInt(enum_info.tag_type, element.children.items[0].CharData, 10) catch null;
             // if (numeric) |num| {
             //     return std.meta.intToEnum(T, num);


### PR DESCRIPTION
While trying to fix #12 I came across a few other things that required attention. 

# Empty responses (e.g. S3 Head Object request)

Head Object provides all of it's payload using HTTP headers. If there are no `metadata` key value pairs on the object, it will be detected to have 1 expected body field. 

I'm sure there are other endpoints like this. 

To resolve this, I changed added additional logic to early return if the `response.body.len` is zero. I also changed the empty response initialiser to use `undefined` for `response` and raw response, as it wouldn't compile otherwise. I'm not a huge fan of this.

# Timestamps

There are several different formats for timestamps in the AWS Rest API:

1. ISO8601 for string timestamps returned in response bodies
2. RFC1123 for string timestamps returned in header values
3. Unix timestamps otherwise

I created a `Timestamp` struct to handle this. It probably needs a bit more attention. 
-------

Please have a read and let me know if you have any concerns. 

-------
Fixes #12 