### PR TITLE
Correctly handle XML responses with "repeated root" arrays

### DIFF
--- a/src/xml_shaper.zig
+++ b/src/xml_shaper.zig
@@ -122,16 +122,13 @@ fn detectArrayStyle(comptime T: type, element: *xml.Element, options: ParseOptio
     };
 
     var matching_fields: usize = 0;
-    for (element.children.items) |content| {
-        switch (content) {
-            .Element => |el| {
-                for (field_names) |field_name| {
-                    if (std.mem.eql(u8, field_name, el.tag)) {
-                        matching_fields += 1;
-                    }
-                }
-            },
-            else => continue,
+    var element_iterator = element.elements();
+
+    while (element_iterator.next()) |el| {
+        for (field_names) |field_name| {
+            if (std.mem.eql(u8, field_name, el.tag)) {
+                matching_fields += 1;
+            }
         }
     }
 

--- a/src/xml_shaper.zig
+++ b/src/xml_shaper.zig
@@ -380,7 +380,7 @@ fn parseInternal(comptime T: type, element: *xml.Element, options: ParseOptions)
                     if (ptr_info.child != u8) {
                         const array_style = try detectArrayStyle(ptr_info.child, element, options);
 
-                        std.log.debug("type = {s}, style = {s}, ptr_info.child == {s}, element = {s}", .{ @typeName(T), @tagName(array_style), @typeName(ptr_info.child), element.tag });
+                        log.debug("type = {s}, style = {s}, ptr_info.child == {s}, element = {s}", .{ @typeName(T), @tagName(array_style), @typeName(ptr_info.child), element.tag });
 
                         var children = std.ArrayList(ptr_info.child).init(allocator);
                         defer children.deinit();

--- a/src/xml_shaper.zig
+++ b/src/xml_shaper.zig
@@ -111,7 +111,6 @@ fn detectArrayStyle(comptime T: type, element: *xml.Element, options: ParseOptio
     const field_names = comptime blk: {
         var result: [std.meta.fieldNames(T).len]struct {
             []const u8,
-            void,
         } = undefined;
 
         for (std.meta.fieldNames(T), 0..) |field_name, i| {
@@ -120,7 +119,7 @@ fn detectArrayStyle(comptime T: type, element: *xml.Element, options: ParseOptio
             else
                 field_name;
 
-            result[i] = .{ key, {} };
+            result[i] = .{key};
         }
 
         break :blk std.StaticStringMap(void).initComptime(result);


### PR DESCRIPTION
It seems that there are two main styles in the AWS responses, with most being handled by the existing code. However, calls like `ListBucket` return a repeated root style array:

 ```xml
 <ListBucketResult>
   <Contents><Key>file1</Key></Contents>
   <Contents><Key>file2</Key></Contents>
 </ListBucketResult>
 ```

The existing code tried to parse `Key` as a `Response`, which clearly does not work. There are two core changes that I made:

1. Added a `detectArrayStyle` that checks if the response is actually the struct we want to parse, or if it is a normal style array. 
2. Added `next_sibling` to `Element` so that we can loop through each elements siblings to get the resulting repeated root style array. 

I was initially going to replace the XML parsing using an external library, thinking it would be easier. Hence the changes to dependency management. Once I understood the problem better I realised I didn't need an external library. I do think in future it would be good to use something external like `zig-xml` but not now. 

-----
Btw. I made up the name "repeated root". It probably has a name but I don't know what it is. 