### PR TITLE
Refactor ISO 8601 date parsing

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,8 +22,8 @@
             .hash = "N-V-__8AAKWdeiawujEcrfukQbb8lLAiQIRT0uG5gCcm4b7W",
         },
         .zeit = .{
-            .url = "git+https://github.com/rockorager/zeit#fb6557ad4bd0cd0f0f728ae978061d7fe992c528",
-            .hash = "zeit-0.6.0-5I6bk29nAgDhK6AVMtXMWhkKTYgUncrWjnlI_8X9DPSd",
+            .url = "https://github.com/deevus/zeit/archive/refs/heads/iso8601-basic.tar.gz",
+            .hash = "zeit-0.6.0-5I6bkzt5AgC1_BCuSzXkV0JHeF4Mhti1Z_jFC7E_nmD2",
         },
         .date = .{
             .path = "lib/date",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -22,7 +22,7 @@
             .hash = "N-V-__8AAKWdeiawujEcrfukQbb8lLAiQIRT0uG5gCcm4b7W",
         },
         .zeit = .{
-            .url = "https://github.com/deevus/zeit/archive/refs/heads/iso8601-basic.tar.gz",
+            .url = "git+https://github.com/rockorager/zeit#f86d568b89a5922f084dae524a1eaf709855cd5e",
             .hash = "zeit-0.6.0-5I6bkzt5AgC1_BCuSzXkV0JHeF4Mhti1Z_jFC7E_nmD2",
         },
         .date = .{

--- a/lib/date/build.zig.zon
+++ b/lib/date/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .zeit = .{
-            .url = "git+https://github.com/rockorager/zeit#fb6557ad4bd0cd0f0f728ae978061d7fe992c528",
-            .hash = "zeit-0.6.0-5I6bk29nAgDhK6AVMtXMWhkKTYgUncrWjnlI_8X9DPSd",
+            .url = "https://github.com/deevus/zeit/archive/refs/heads/iso8601-basic.tar.gz",
+            .hash = "zeit-0.6.0-5I6bkzt5AgC1_BCuSzXkV0JHeF4Mhti1Z_jFC7E_nmD2",
         },
         .json = .{
             .path = "../json",

--- a/lib/date/build.zig.zon
+++ b/lib/date/build.zig.zon
@@ -5,7 +5,7 @@
     .minimum_zig_version = "0.14.0",
     .dependencies = .{
         .zeit = .{
-            .url = "https://github.com/deevus/zeit/archive/refs/heads/iso8601-basic.tar.gz",
+            .url = "git+https://github.com/rockorager/zeit#f86d568b89a5922f084dae524a1eaf709855cd5e",
             .hash = "zeit-0.6.0-5I6bkzt5AgC1_BCuSzXkV0JHeF4Mhti1Z_jFC7E_nmD2",
         },
         .json = .{

--- a/lib/date/src/parsing.zig
+++ b/lib/date/src/parsing.zig
@@ -1,7 +1,3 @@
-// From https://gist.github.com/WoodyAtHome/3ef50b17f0fa2860ac52b97af12f8d15
-// Translated from German. We don't need any local time for this use case, and conversion
-// really requires the TZ DB.
-
 const std = @import("std");
 const log = std.log.scoped(.date);
 const zeit = @import("zeit");


### PR DESCRIPTION
Updates the date parsing code to use `zeit` for ISO 8601 basic format. 

There is a bug in zeit master that breaks on basic format dates currently. I have opened a PR there to fix it. 

Issue: https://github.com/rockorager/zeit/issues/33
PR: https://github.com/rockorager/zeit/pull/34

This PR will be ready once the above are resolved and I update zeit back to a stable release. 